### PR TITLE
Timing randomization

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -109,7 +109,12 @@ func (pxy *Proxy) Start(ctx context.Context) {
 
 			var h Handler
 			if pkt.IsConnectMethod() {
-				h = handler.NewHttpsHandler(pxy.timeout, pxy.windowSize, pxy.allowedPattern, matched)
+				h = handler.NewHttpsHandler(
+					handler.WithTimeout(pxy.timeout),
+					handler.WithWindowSize(pxy.windowSize),
+					handler.WithAllowedPatterns(pxy.allowedPattern),
+					handler.WithExploit(matched),
+				)
 			} else {
 				h = handler.NewHttpHandler(pxy.timeout)
 			}

--- a/util/args.go
+++ b/util/args.go
@@ -22,6 +22,9 @@ type Args struct {
 	AllowedPattern StringArray
 	WindowSize     uint16
 	Version        bool
+	TimingRandomization bool
+	TimingDelayMin      uint16
+	TimingDelayMax      uint16
 }
 
 type StringArray []string
@@ -59,6 +62,9 @@ fragmentation for the first data packet and the rest
 		"bypass DPI only on packets matching this regex pattern; can be given multiple times",
 	)
 	flag.BoolVar(&args.DnsIPv4Only, "dns-ipv4-only", false, "resolve only version 4 addresses")
+	flag.BoolVar(&args.TimingRandomization, "timing-randomization", false, "enable timing randomization between packet chunks")
+	uintNVar(&args.TimingDelayMin, "timing-delay-min", 5, "minimum delay in milliseconds for timing randomization")
+	uintNVar(&args.TimingDelayMax, "timing-delay-max", 50, "maximum delay in milliseconds for timing randomization")
 
 	flag.Parse()
 

--- a/util/config.go
+++ b/util/config.go
@@ -21,6 +21,9 @@ type Config struct {
 	Timeout         int
 	WindowSize      int
 	AllowedPatterns []*regexp.Regexp
+	TimingRandomization bool
+	TimingDelayMin      uint16
+	TimingDelayMax      uint16
 }
 
 var config *Config
@@ -45,6 +48,14 @@ func (c *Config) Load(args *Args) {
 	c.Timeout = int(args.Timeout)
 	c.AllowedPatterns = parseAllowedPattern(args.AllowedPattern)
 	c.WindowSize = int(args.WindowSize)
+	c.TimingRandomization = args.TimingRandomization
+	c.TimingDelayMin = args.TimingDelayMin
+	c.TimingDelayMax = args.TimingDelayMax
+
+	// Add validation
+	if c.TimingDelayMin > c.TimingDelayMax {
+		c.TimingDelayMin = c.TimingDelayMax
+	}
 }
 
 func parseAllowedPattern(patterns StringArray) []*regexp.Regexp {


### PR DESCRIPTION
- Refactored NewHttpsHandler constructor to minimize argument passing.
- Added timing randomizations to CONNECT http methods.

Related arguments when running spoofdpi:
`spoofdpi  -timing-randomization -timing-delay-min 1 -timing-delay-max 10`