### PR TITLE
feat: add timing randomization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Usage: spoofdpi [options...]
         bypass DPI only on packets matching this regex pattern; can be given multiple times
   -port value
         port (default 8080)
+  -random-timing value
+        enable random timing delays between packet chunks: short, medium, long (default "short")
   -silent
         do not show the banner and server information at start up
   -system-proxy

--- a/proxy/handler/https.go
+++ b/proxy/handler/https.go
@@ -3,9 +3,11 @@ package handler
 import (
 	"context"
 	"errors"
+	"math/rand"
 	"net"
 	"regexp"
 	"strconv"
+	"time"
 
 	"github.com/xvzc/SpoofDPI/packet"
 	"github.com/xvzc/SpoofDPI/util"
@@ -15,19 +17,27 @@ import (
 // HttpsHandlerConfig contains configuration options for HTTPS handler
 type HttpsHandlerConfig struct {
 	// Core settings
-	Timeout         int                  // Connection timeout in milliseconds
-	WindowSize      int                  // Fragmentation window size
-	AllowedPatterns []*regexp.Regexp     // Regex patterns to bypass DPI
-	Exploit         bool                 // Enable DPI bypass exploit
+	Timeout         int              // Connection timeout in milliseconds
+	WindowSize      int              // Fragmentation window size
+	AllowedPatterns []*regexp.Regexp // Regex patterns to bypass DPI
+	Exploit         bool             // Enable DPI bypass exploit
+
+	// Timing randomization settings
+	TimingRandomization bool   // Enable timing randomization
+	TimingDelayMin      uint16 // Minimum delay in milliseconds
+	TimingDelayMax      uint16 // Maximum delay in milliseconds
 }
 
 // DefaultHttpsHandlerConfig returns default configuration
 func DefaultHttpsHandlerConfig() HttpsHandlerConfig {
 	return HttpsHandlerConfig{
-		Timeout:         0,     // No timeout
-		WindowSize:      0,     // Legacy fragmentation
-		AllowedPatterns: nil,   // No pattern filtering
-		Exploit:         true,  // Enable DPI bypass
+		Timeout:             0,     // No timeout
+		WindowSize:          0,     // Legacy fragmentation
+		AllowedPatterns:     nil,   // No pattern filtering
+		Exploit:             true,  // Enable DPI bypass
+		TimingRandomization: false, // Disabled by default
+		TimingDelayMin:      5,     // 5ms minimum
+		TimingDelayMax:      50,    // 50ms maximum
 	}
 }
 
@@ -36,11 +46,11 @@ func (c HttpsHandlerConfig) Validate() error {
 	if c.Timeout < 0 {
 		return errors.New("timeout cannot be negative")
 	}
-	
+
 	if c.WindowSize < 0 {
 		return errors.New("window size cannot be negative")
 	}
-	
+
 	return nil
 }
 
@@ -82,23 +92,38 @@ func WithExploit(exploit bool) HttpsHandlerOption {
 	}
 }
 
+// WithTimingRandomization enables timing randomization with min/max delays
+func WithTimingRandomization(min, max uint16) HttpsHandlerOption {
+	return func(c *HttpsHandlerConfig) {
+		c.TimingRandomization = true
+		c.TimingDelayMin = min
+		c.TimingDelayMax = max
+	}
+}
+
+// WithoutTimingRandomization disables timing randomization
+func WithoutTimingRandomization() HttpsHandlerOption {
+	return func(c *HttpsHandlerConfig) {
+		c.TimingRandomization = false
+	}
+}
 
 // NewHttpsHandler creates a new HTTPS handler with functional options
 func NewHttpsHandler(opts ...HttpsHandlerOption) *HttpsHandler {
 	// Start with default configuration
 	config := DefaultHttpsHandlerConfig()
-	
+
 	// Apply all options
 	for _, opt := range opts {
 		opt(&config)
 	}
-	
+
 	// Validate final configuration
 	if err := config.Validate(); err != nil {
 		// Use defaults if validation fails
 		config = DefaultHttpsHandlerConfig()
 	}
-	
+
 	return &HttpsHandler{
 		bufferSize: 1024,
 		protocol:   "HTTPS",
@@ -107,6 +132,24 @@ func NewHttpsHandler(opts ...HttpsHandlerOption) *HttpsHandler {
 	}
 }
 
+func (h *HttpsHandler) randomDelay(ctx context.Context) {
+	if !h.config.TimingRandomization {
+		return
+	}
+
+	if h.config.TimingDelayMin >= h.config.TimingDelayMax {
+		return
+	}
+
+	// Generate random delay between min and max
+	delayRange := h.config.TimingDelayMax - h.config.TimingDelayMin
+	delay := h.config.TimingDelayMin + uint16(rand.Intn(int(delayRange)+1))
+
+	logger := log.GetCtxLogger(ctx)
+	logger.Debug().Msgf("applying timing delay: %dms", delay)
+
+	time.Sleep(time.Duration(delay) * time.Millisecond)
+}
 
 func (h *HttpsHandler) Serve(ctx context.Context, lConn *net.TCPConn, initPkt *packet.HttpRequest, ip string) {
 	ctx = util.GetCtxWithScope(ctx, h.protocol)
@@ -155,7 +198,7 @@ func (h *HttpsHandler) Serve(ctx context.Context, lConn *net.TCPConn, initPkt *p
 	if h.config.Exploit {
 		logger.Debug().Msgf("writing chunked client hello to %s", initPkt.Domain())
 		chunks := splitInChunks(ctx, clientHello, h.config.WindowSize)
-		if _, err := writeChunks(rConn, chunks); err != nil {
+		if _, err := h.writeChunks(ctx, rConn, chunks); err != nil {
 			logger.Debug().Msgf("error writing chunked client hello to %s: %s", initPkt.Domain(), err)
 			return
 		}
@@ -237,12 +280,18 @@ func splitInChunks(ctx context.Context, bytes []byte, size int) [][]byte {
 	return [][]byte{raw[:1], raw[1:]}
 }
 
-func writeChunks(conn *net.TCPConn, c [][]byte) (n int, err error) {
+func (h *HttpsHandler) writeChunks(ctx context.Context, conn *net.TCPConn, c [][]byte) (n int, err error) {
+
 	total := 0
 	for i := 0; i < len(c); i++ {
+		// Apply delays to 15% of chunks randomly (except first chunk)
+		if i > 0 && h.config.TimingRandomization && rand.Float32() < 0.15 {
+			h.randomDelay(ctx)
+		}
+
 		b, err := conn.Write(c[i])
 		if err != nil {
-			return 0, nil
+			return 0, err
 		}
 
 		total += b

--- a/util/args.go
+++ b/util/args.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"os"
 	"strconv"
+	"strings"
 	"unsafe"
 )
 
@@ -22,6 +24,7 @@ type Args struct {
 	AllowedPattern StringArray
 	WindowSize     uint16
 	Version        bool
+	RandomTiming TimingFlag
 }
 
 type StringArray []string
@@ -34,6 +37,22 @@ func (arr *StringArray) Set(value string) error {
 	*arr = append(*arr, value)
 	return nil
 }
+
+type TimingFlag struct {
+	Value string
+	IsSet bool
+}
+
+func (t *TimingFlag) String() string {
+	return t.Value
+}
+
+func (t *TimingFlag) Set(value string) error {
+	t.Value = value
+	t.IsSet = true
+	return nil
+}
+
 
 func ParseArgs() *Args {
 	args := new(Args)
@@ -59,8 +78,21 @@ fragmentation for the first data packet and the rest
 		"bypass DPI only on packets matching this regex pattern; can be given multiple times",
 	)
 	flag.BoolVar(&args.DnsIPv4Only, "dns-ipv4-only", false, "resolve only version 4 addresses")
+	flag.Var(&args.RandomTiming, "random-timing", "enable random timing delays: short, medium, long (defaults to short)")
 
 	flag.Parse()
+	
+	// Handle --random-timing without value (set default to "short")
+	for i, arg := range os.Args {
+		if arg == "--random-timing" || arg == "-random-timing" {
+			// Check if next arg exists and is not a flag
+			if i+1 >= len(os.Args) || strings.HasPrefix(os.Args[i+1], "-") {
+				args.RandomTiming.Value = "short"
+				args.RandomTiming.IsSet = true
+			}
+			break
+		}
+	}
 
 	return args
 }

--- a/util/config.go
+++ b/util/config.go
@@ -9,18 +9,21 @@ import (
 )
 
 type Config struct {
-	Addr            string
-	Port            int
-	DnsAddr         string
-	DnsPort         int
-	DnsIPv4Only     bool
-	EnableDoh       bool
-	Debug           bool
-	Silent          bool
-	SystemProxy     bool
-	Timeout         int
-	WindowSize      int
-	AllowedPatterns []*regexp.Regexp
+	Addr                string
+	Port                int
+	DnsAddr             string
+	DnsPort             int
+	DnsIPv4Only         bool
+	EnableDoh           bool
+	Debug               bool
+	Silent              bool
+	SystemProxy         bool
+	Timeout             int
+	WindowSize          int
+	AllowedPatterns     []*regexp.Regexp
+	TimingRandomization bool
+	TimingDelayMin      uint16
+	TimingDelayMax      uint16
 }
 
 var config *Config
@@ -45,6 +48,34 @@ func (c *Config) Load(args *Args) {
 	c.Timeout = int(args.Timeout)
 	c.AllowedPatterns = parseAllowedPattern(args.AllowedPattern)
 	c.WindowSize = int(args.WindowSize)
+	// Handle random timing argument
+	if args.RandomTiming.IsSet {
+		c.TimingRandomization = true
+		// Convert timing delay preset to min/max values
+		preset := args.RandomTiming.Value
+		if preset == "" {
+			preset = "short" // Default when flag is used without value
+		}
+		switch preset {
+		case "short":
+			c.TimingDelayMin = 5
+			c.TimingDelayMax = 25
+		case "medium":
+			c.TimingDelayMin = 25
+			c.TimingDelayMax = 50
+		case "long":
+			c.TimingDelayMin = 50
+			c.TimingDelayMax = 100
+		default:
+			// Default to short for invalid values
+			c.TimingDelayMin = 5
+			c.TimingDelayMax = 25
+		}
+	} else {
+		c.TimingRandomization = false
+		c.TimingDelayMin = 0
+		c.TimingDelayMax = 0
+	}
 }
 
 func parseAllowedPattern(patterns StringArray) []*regexp.Regexp {


### PR DESCRIPTION
- Remove unnecessary validation for timing delays
- Enable debug logging for timing delay application
- Fix randomization to apply to 15% of chunks instead of all
- Replace separate timing flags with preset-based --random-timing flag
- Add short/medium/long presets for better user experience
- Update README.md with documentation

Here's the new usage:
spoofdpi --random-timing short
Possible values for random-timing is short, medium or long. If no value is given then short is assumed.

My previous implementation was adding delay to every TLS fragment which defeated the purpose of randomness. Also reduced to one flag for ease of use.

Short: 5-25 ms
Medium: 25-50 ms
Long: 50-100 ms